### PR TITLE
change the division from int to float

### DIFF
--- a/02-Improving-Deep-Neural-Networks/week2/Programming-Assignments/opt_utils.py
+++ b/02-Improving-Deep-Neural-Networks/week2/Programming-Assignments/opt_utils.py
@@ -70,7 +70,7 @@ def initialize_parameters(layer_dims):
     L = len(layer_dims) # number of layers in the network
 
     for l in range(1, L):
-        parameters['W' + str(l)] = np.random.randn(layer_dims[l], layer_dims[l-1])*  np.sqrt(2 / layer_dims[l-1])
+        parameters['W' + str(l)] = np.random.randn(layer_dims[l], layer_dims[l-1])*  np.sqrt(2. / layer_dims[l-1])
         parameters['b' + str(l)] = np.zeros((layer_dims[l], 1))
         
         assert(parameters['W' + str(l)].shape == layer_dims[l], layer_dims[l-1])


### PR DESCRIPTION
for cases where layer_dims[l-1] > 2, 2/layer_dims[l-1] becomes 0 and then parameters['Wl'] = 0.
So all the results were wrong. After the changes, the algorithm is working fine.